### PR TITLE
Update to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quickskeleton"
 version = "0.4.7"
 authors = ["arthrp"]
+edition = "2018"
 
 [dependencies]
 handlebars = "0.25.0"

--- a/src/file_helper.rs
+++ b/src/file_helper.rs
@@ -1,26 +1,28 @@
-use std::path::Path;
+use handlebars::Handlebars;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::prelude::*;
-use zip::read::ZipFile;
-use std::collections::BTreeMap;
-use handlebars::Handlebars;
-use std::path::PathBuf;
 use std::path::Component::ParentDir;
+use std::path::Path;
+use std::path::PathBuf;
+use zip::read::ZipFile;
 
-pub fn write_file(file: &mut ZipFile, outpath: &Path, data: &BTreeMap<String,String>) {
+pub fn write_file(file: &mut ZipFile, outpath: &Path, data: &BTreeMap<String, String>) {
     let mut file_contents = String::new();
 
     file.read_to_string(&mut file_contents).unwrap();
     let mut outfile = fs::File::create(&outpath).unwrap();
 
     let mut handlebars = Handlebars::new();
-    assert!(handlebars.register_template_string("t1", file_contents).is_ok());
+    assert!(handlebars
+        .register_template_string("t1", file_contents)
+        .is_ok());
 
     let res = handlebars.render("t1", data).unwrap();
-    outfile.write_all(&res.as_bytes());
+    outfile.write_all(&res.as_bytes()).unwrap();
 }
 
-pub fn create_directory(outpath: &Path) -> () {
+pub fn create_directory(outpath: &Path) {
     fs::create_dir_all(&outpath).unwrap();
 }
 
@@ -30,11 +32,11 @@ pub fn sanitize_filename(filename: &str) -> PathBuf {
         None => filename,
     };
 
-    return Path::new(no_null_filename)
+    Path::new(no_null_filename)
         .components()
         .filter(|component| *component != ParentDir)
         .fold(PathBuf::new(), |mut path, ref cur| {
             path.push(cur.as_os_str());
             path
-        });
+        })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,24 @@
-#![allow(unused_parens)]
-#![allow(unused_must_use)]
+#![allow(clippy::try_err)]
 
-mod models;
 mod file_helper;
+mod models;
 
+use models::TemplateParameter;
+use rustc_serialize::json;
+use std::collections::BTreeMap;
 use std::env;
-use std::path::Path;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::Seek;
-use rustc_serialize::json;
-use std::collections::BTreeMap;
-use models::TemplateParameter;
+use std::path::Path;
+use text_io::{read, try_read, try_scan};
+use walkdir::{DirEntry, WalkDir};
 use zip::write::FileOptions;
-use walkdir::{WalkDir, DirEntry};
-
-extern crate zip;
-extern crate rustc_serialize;
-extern crate handlebars;
-extern crate walkdir;
-#[macro_use] extern crate text_io;
-
 
 fn main() {
-    let args : Vec<String> = env::args().collect();
-	
-    if (env::args().count() < 3){
+    let args: Vec<String> = env::args().collect();
+
+    if env::args().count() < 3 {
         println!("Wrong arguments supplied.");
         print_usage(&args[0]);
         return;
@@ -33,16 +26,16 @@ fn main() {
 
     let mode = &args[1];
 
-    if(mode == "-c") {
+    if mode == "-c" {
         let file_path = Path::new(&args[2]);
         let zip_file = File::open(&file_path).unwrap();
         let mut archive = zip::ZipArchive::new(zip_file).unwrap();
-        let params_json : Vec<TemplateParameter> = json::decode(&get_param_json(&mut archive)).unwrap();
+        let params_json: Vec<TemplateParameter> =
+            json::decode(&get_param_json(&mut archive)).unwrap();
 
-        let data : BTreeMap<String,String> = fill_data(&params_json);
+        let data: BTreeMap<String, String> = fill_data(&params_json);
         extract_content(&mut archive, &data);
-    }
-    else if(mode == "-n") {
+    } else if mode == "-n" {
         let dir_to_zip = &args[2];
         let folder_name = &args[4];
         let file_name = format!("{}.zip", folder_name);
@@ -50,18 +43,28 @@ fn main() {
         let file = File::create(zip_file_name).unwrap();
 
         let walkdir = WalkDir::new(dir_to_zip);
-        let walkdirIt = walkdir.into_iter();
+        let walkdir_iter = walkdir.into_iter();
 
-        zip_dir(&mut walkdirIt.filter_map(|e| e.ok()), dir_to_zip, file, folder_name);
-    }
-    else { 
+        zip_dir(
+            &mut walkdir_iter.filter_map(|e| e.ok()),
+            dir_to_zip,
+            file,
+            folder_name,
+        )
+        .unwrap()
+    } else {
         print_usage(&args[0]);
     }
 }
 
-fn zip_dir<T>(walkdirIt: &mut Iterator<Item=DirEntry>, prefix: &str, writer: T, folder_name: &str)
-              -> zip::result::ZipResult<()>
-    where T: Write+Seek
+fn zip_dir<T>(
+    walkdir_iter: &mut dyn Iterator<Item = DirEntry>,
+    prefix: &str,
+    writer: T,
+    folder_name: &str,
+) -> zip::result::ZipResult<()>
+where
+    T: Write + Seek,
 {
     let empty_params = b"[]";
     let mut zip = zip::ZipWriter::new(writer);
@@ -70,14 +73,17 @@ fn zip_dir<T>(walkdirIt: &mut Iterator<Item=DirEntry>, prefix: &str, writer: T, 
         .unix_permissions(0o755);
 
     let mut buffer = Vec::new();
-    zip.start_file("parameters.json", FileOptions::default());
-    zip.write_all(empty_params);
+    zip.start_file("parameters.json", FileOptions::default())?;
+    zip.write_all(empty_params)?;
+    zip.add_directory(format!("{}/", folder_name), FileOptions::default())?;
 
-    zip.add_directory(format!("{}/", folder_name), FileOptions::default());
-
-    for entry in walkdirIt {
+    for entry in walkdir_iter {
         let path = entry.path();
-        let name = path.strip_prefix(Path::new(prefix)).unwrap().to_str().unwrap();
+        let name = path
+            .strip_prefix(Path::new(prefix))
+            .unwrap()
+            .to_str()
+            .unwrap();
 
         if path.is_file() {
             println!("adding {:?} as {:?} ...", path, name);
@@ -90,31 +96,33 @@ fn zip_dir<T>(walkdirIt: &mut Iterator<Item=DirEntry>, prefix: &str, writer: T, 
         }
     }
     zip.finish()?;
-    Result::Ok(())
+    Ok(())
 }
 
-fn extract_content<R: Read + Seek>(archive: &mut zip::ZipArchive<R>, data: &BTreeMap<String,String>) -> () {
-    for i in 0..archive.len(){
+fn extract_content<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    data: &BTreeMap<String, String>,
+) {
+    for i in 0..archive.len() {
         let mut archive_file = archive.by_index(i).unwrap();
 
-        if (archive_file.name() == "parameters.json"){
+        if archive_file.name() == "parameters.json" {
             continue;
         }
 
         let write_path = file_helper::sanitize_filename(archive_file.name());
-        file_helper::create_directory(write_path.parent().unwrap_or(Path::new("")));
+        file_helper::create_directory(write_path.parent().unwrap_or_else(|| Path::new("")));
 
-        if (&*archive_file.name()).ends_with("/") {
+        if (&*archive_file.name()).ends_with('/') {
             file_helper::create_directory(&write_path);
-        }
-        else {
+        } else {
             file_helper::write_file(&mut archive_file, &write_path, &data);
         }
     }
 }
 
 fn get_param_json<R: Read + Seek>(archive: &mut zip::ZipArchive<R>) -> String {
-    let mut param_file = match archive.by_name("parameters.json"){
+    let mut param_file = match archive.by_name("parameters.json") {
         Ok(file) => file,
         Err(..) => {
             println!("File is not a valid template");
@@ -125,27 +133,33 @@ fn get_param_json<R: Read + Seek>(archive: &mut zip::ZipArchive<R>) -> String {
     let mut param_file_contents = String::new();
     param_file.read_to_string(&mut param_file_contents).unwrap();
 
-    return param_file_contents;
+    param_file_contents
 }
 
-fn fill_data(params_json: &Vec<TemplateParameter>) -> BTreeMap<String,String> {
+fn fill_data(params_json: &[TemplateParameter]) -> BTreeMap<String, String> {
     let mut data = BTreeMap::new();
     let mut input: String;
 
-    for i in 0..params_json.len(){
-        println!("{}:", params_json[i].desc);
+    for param in params_json {
+        println!("{}:", param.desc);
         input = read!("{}\n");
-        &data.insert(format!("{}", params_json[i].name), format!("{}", input));
+        data.insert(param.name.clone(), input);
     }
 
     println!("Input project folder name:");
     input = read!("{}\n");
-    &data.insert("folder_name".to_string(), format!("{}", input));
+    data.insert("folder_name".to_string(), input);
 
-    return data;
+    data
 }
 
-fn print_usage(name: &String) -> (){
-    println!("Usage: {0} -c [path to template] - scaffold new project", name);
-    println!("{0} -n [forder path] -f [default project folder name] - create template from folder", name);
+fn print_usage(name: &str) {
+    println!(
+        "Usage: {0} -c [path to template] - scaffold new project",
+        name
+    );
+    println!(
+        "{0} -n [forder path] -f [default project folder name] - create template from folder",
+        name
+    );
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,5 +2,5 @@
 pub struct TemplateParameter {
     pub name: String,
     pub value: String,
-    pub desc: String
+    pub desc: String,
 }


### PR DESCRIPTION
This PR updates the code to Rust 2018 edition and fixes most of the reported linting errors by Clippy.

It's up to you whether you merge this or not, but I figured I'd file it to save you some time as my editor was flagging a lot when working on another PR. Most changes are just formatting and best practices, so they don't change much functionally.

The `allow` at the top is because the `read!` macro from `text_io` has a lint issue which is reflected here as well, seeing as the macro injects it into your code. 